### PR TITLE
remove python3 readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ $ pip install -r requirements.txt
 ## Hello OBP
 
 ```bash
-$ python2 hello_obp.py
-
-$ python3 hello.obp3.py
+#compatible with python2 and 3
+$ python hello_obp.py
 ```
 
 


### PR DESCRIPTION
since hello_obp.py is compatible with both versions - py2 and 3, this command no longer needs to be present in readme.md
