### PR TITLE
change default api endpoint to default

### DIFF
--- a/hello_obp.py
+++ b/hello_obp.py
@@ -8,7 +8,7 @@ import sys, time, requests
 # that you can send money from (i.e. be the owner).
 # All properties are now kept in one central place
 
-from props.danskebank import *
+from props.default import *
 #from props.socgen import *
 
 


### PR DESCRIPTION
Hey there,

when I run the demo I get a 404. I assume because the API endpoint is by default: https://danskebank.openbankproject.com/my/logins/direct for authentification

I changed the endpoint to default, so new devs immediately can play with something that works